### PR TITLE
Renamed sql statements to point to correct table names

### DIFF
--- a/AspNet.Identity.Dapper/UserRoleTable.cs
+++ b/AspNet.Identity.Dapper/UserRoleTable.cs
@@ -51,8 +51,8 @@ namespace AspNet.Identity.Dapper
         /// <returns></returns>
         public void Insert(IdentityMember member, int roleId)
         {
-            db.Connection.Execute(@"Insert into AspNetUserRoles (UserId, RoleId) values (@userId, @roleId",
-                new { userId = member.Id, roleId = roleId });
+            db.Connection.Execute(@"Insert into MemberRole (MemberId, RoleId) values (@memberId, @roleId)",
+                new { memberId = member.Id, roleId = roleId });
         }
     }
 }

--- a/AspNet.Identity.Dapper/UserTable.cs
+++ b/AspNet.Identity.Dapper/UserTable.cs
@@ -164,7 +164,7 @@ namespace AspNet.Identity.Dapper
         {
             db.Connection
               .Execute(@"
-                            Update AspNetUsers set UserName = @userName, PasswordHash = @pswHash, SecurityStamp = @secStamp, 
+                            Update Member set UserName = @userName, PasswordHash = @pswHash, SecurityStamp = @secStamp, 
                 Email=@email, EmailConfirmed=@emailconfirmed, PhoneNumber=@phonenumber, PhoneNumberConfirmed=@phonenumberconfirmed,
                 AccessFailedCount=@accesscount, LockoutEnabled=@lockoutenabled, LockoutEndDateUtc=@lockoutenddate, TwoFactorEnabled=@twofactorenabled  
                 WHERE Id = @memberId",


### PR DESCRIPTION
Two of the sql statements were pointing to the old `AspNetUser` tables instead of the new naming convention of `Member`.
